### PR TITLE
API change of average_observed()

### DIFF
--- a/R/average_observed.R
+++ b/R/average_observed.R
@@ -1,33 +1,43 @@
 #' Average Observed
 #'
-#' Calculates average observed `y` values over one or multiple X variables `v`.
-#' The `y` argument can either be a numeric vector or a column name in `data`.
+#' Calculates average observed `y` values over one or multiple `X` variables.
 #' This function is a convenience wrapper around [marginal()].
 #'
+#' @param X A vector, matrix, or data.frame with variable(s) to be shown on the x axis.
+#' @param y A numeric vector of observed responses.
+#' @param w An optional numeric vector of weights.
+#' @param x_name If `X` is a vector: what is the name of the variable? By default "x".
 #' @inheritParams marginal
 #' @inherit marginal return
 #' @param ... Currently unused.
 #' @seealso [marginal()]
 #' @export
 #' @examples
-#' M <- average_observed(v = "Species", y = "Sepal.Length", data = iris)
+#' M <- average_observed(iris$Species, y = iris$Sepal.Length)
 #' M
 #' M |> plot()
+#'
+#' # Or multiple potential features X
+#' average_observed(iris[2:5], y = iris[, 1], breaks = 5) |>
+#'   plot()
 average_observed <- function(
-    v,
-    data,
+    X,
     y,
     w = NULL,
+    x_name = "x",
     breaks = "Sturges",
     right = TRUE,
     discrete_m = 5L,
     outlier_iqr = 2,
     ...
 ) {
+  if (NCOL(X) == 1L && (is.vector(X) || is.factor(X))) {
+    X <- stats::setNames(data.frame(X), x_name)
+  }
   marginal.default(
     object = NULL,
-    v = v,
-    data = data,
+    v = colnames(X),
+    data = X,
     y = y,
     w = w,
     breaks = breaks,

--- a/R/postprocess.R
+++ b/R/postprocess.R
@@ -18,7 +18,8 @@
 #'   numeric X. Note that partial dependence of numeric X is always evaluated at
 #'   bar means, not centers. Vectorized over `x`.
 #' @param collapse_m If a categorical X has more than `collapse_m` levels,
-#'   rare levels are collapsed into a new level "Other".
+#'   rare levels are collapsed into a new level "Other". Standard deviations are
+#'   collapsed via root of the weighted average variances.
 #'   By default 30. Set to `Inf` for no collapsing. Vectorized over `x`.
 #' @param drop_below_n Drop bins with weight below this value. Applied after the
 #'   effect of `collapse_m`. Vectorized over `x`.
@@ -142,7 +143,7 @@ main_effect_importance <- function(x, statistic = NULL) {
     eval_at = oth,
     N = sum(N),
     collapse::fmean(M, w = N, drop = FALSE, na.rm = TRUE),
-    sqrt(collapse::fsum(S^2 * (N - 1), drop = FALSE, na.rm = TRUE) / (sum(N) - 1))  # OK?
+    sqrt(collapse::fmean(S^2, w = N, drop = FALSE, na.rm = TRUE))
   )
   rbind(x_keep, x_new)  # Column order of x_new does not matter
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ df <- getOMLDataSet(data.id = 45106L)$data
 xvars <- c("year", "town", "driver_age", "car_weight", "car_power", "car_age")
 
 # 0.3s on laptop
-average_observed(xvars, data = df, y = "claim_nb") |>
+average_observed(df[xvars], y = df$claim_nb) |>
   postprocess(sort = TRUE) |> 
   plot(share_y = TRUE)
 ```

--- a/man/average_observed.Rd
+++ b/man/average_observed.Rd
@@ -5,10 +5,10 @@
 \title{Average Observed}
 \usage{
 average_observed(
-  v,
-  data,
+  X,
   y,
   w = NULL,
+  x_name = "x",
   breaks = "Sturges",
   right = TRUE,
   discrete_m = 5L,
@@ -17,14 +17,13 @@ average_observed(
 )
 }
 \arguments{
-\item{v}{Vector of variable names to calculate statistics.}
+\item{X}{A vector, matrix, or data.frame with variable(s) to be shown on the x axis.}
 
-\item{data}{Matrix or data.frame.}
+\item{y}{A numeric vector of observed responses.}
 
-\item{y}{Numeric vector with observed values of the response.
-Can also be a column name in \code{data}. Omitted if \code{NULL} (default).}
+\item{w}{An optional numeric vector of weights.}
 
-\item{w}{Optional vector with case weights. Can also be a column name in \code{data}.}
+\item{x_name}{If \code{X} is a vector: what is the name of the variable? By default "x".}
 
 \item{breaks}{An integer, vector, string or function specifying the bins
 of the numeric X variables as in \code{\link[graphics:hist]{graphics::hist()}}. The default is "Sturges".
@@ -51,14 +50,17 @@ A list (of class "marginal") with a data.frame of statistics per feature. Use
 single bracket subsetting to select part of the output.
 }
 \description{
-Calculates average observed \code{y} values over one or multiple X variables \code{v}.
-The \code{y} argument can either be a numeric vector or a column name in \code{data}.
+Calculates average observed \code{y} values over one or multiple \code{X} variables.
 This function is a convenience wrapper around \code{\link[=marginal]{marginal()}}.
 }
 \examples{
-M <- average_observed(v = "Species", y = "Sepal.Length", data = iris)
+M <- average_observed(iris$Species, y = iris$Sepal.Length)
 M
 M |> plot()
+
+# Or multiple potential features X
+average_observed(iris[2:5], y = iris[, 1], breaks = 5) |>
+  plot()
 }
 \seealso{
 \code{\link[=marginal]{marginal()}}

--- a/man/postprocess.Rd
+++ b/man/postprocess.Rd
@@ -32,7 +32,8 @@ numeric X. Note that partial dependence of numeric X is always evaluated at
 bar means, not centers. Vectorized over \code{x}.}
 
 \item{collapse_m}{If a categorical X has more than \code{collapse_m} levels,
-rare levels are collapsed into a new level "Other".
+rare levels are collapsed into a new level "Other". Standard deviations are
+collapsed via root of the weighted average variances.
 By default 30. Set to \code{Inf} for no collapsing. Vectorized over \code{x}.}
 
 \item{drop_below_n}{Drop bins with weight below this value. Applied after the

--- a/tests/testthat/test-average_observed.R
+++ b/tests/testthat/test-average_observed.R
@@ -2,7 +2,7 @@ test_that("average_observed() is consistent with marginal()", {
   fit <- lm(Sepal.Length ~ ., data = iris)
   v <- c("Sepal.Width", "Species")
 
-  avg_obs <- average_observed(v = v, data = iris, y = iris$Sepal.Length, w = 1:150)
+  avg_obs <- average_observed(iris[v], y = iris$Sepal.Length, w = 1:150)
   marg <- marginal(
     fit,
     v = v,


### PR DESCRIPTION
This PR switches from the verbose API `average_observed(v, data, y)` to the more direct API `average_observed(X, y)`. In case X is a vector, the new argument `x_name` can overwrite the default "x".